### PR TITLE
Change suggestion (operator precedence): pzbcm_edge_detector.sv

### DIFF
--- a/pzbcm_edge_detector/pzbcm_edge_detector.sv
+++ b/pzbcm_edge_detector/pzbcm_edge_detector.sv
@@ -17,7 +17,7 @@ module pzbcm_edge_detector #(
 );
   logic [WIDTH-1:0] d;
 
-  assign  o_edge    = ( i_d) ^ ( d) & (~i_clear);
+  assign  o_edge    = ( i_d  ^   d) & (~i_clear);
   assign  o_posedge = ( i_d) & (~d) & (~i_clear);
   assign  o_negedge = (~i_d) & ( d) & (~i_clear);
 


### PR DESCRIPTION
Change suggestion (operator precedence):

What: ^ and & precedence makes o_edge compute i_d ^ (d & ~i_clear) instead of (i_d ^ d) & ~i_clear.
Impact: False edge detections when i_clear is asserted.
Fix: Add parentheses to gate the XOR result.